### PR TITLE
Refactor CrMissingClassName.java,CrMissingStateName.java,CrUML.java

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,5 +8,8 @@
       </list>
     </option>
   </component>
+  <component name="PDMPlugin">
+    <option name="skipTestSources" value="false" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
 </project>

--- a/src/argouml-app/pom.xml
+++ b/src/argouml-app/pom.xml
@@ -182,6 +182,12 @@
     	<version>0.35.2-SNAPSHOT</version>
     	<scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.argouml</groupId>
+          <artifactId>argouml-model</artifactId>
+          <version>0.35.2-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
 
   <name>argouml-app</name>

--- a/src/argouml-app/src/org/argouml/uml/cognitive/critics/CrMissingStateName.java
+++ b/src/argouml-app/src/org/argouml/uml/cognitive/critics/CrMissingStateName.java
@@ -50,22 +50,19 @@ import org.argouml.cognitive.critics.Wizard;
 import org.argouml.model.Model;
 import org.argouml.uml.cognitive.UMLDecision;
 
-
 /**
- * A critic to detect whether a state has a name.
- * Does not apply to all kinds of states!
- * E.g. excluded are final state, initial state, action state,...
+ * This critics tests if a ModelElement has a name.
  */
-public class CrMissingStateName extends CrUML {
+class CrMissingClassName extends CrUML {
 
     /**
      * The constructor.
      */
-    public CrMissingStateName() {
+    public CrMissingClassName() {
         setupHeadAndDesc();
-	addSupportedDecision(UMLDecision.NAMING);
-	setKnowledgeTypes(Critic.KT_COMPLETENESS, Critic.KT_SYNTAX);
-	addTrigger("name");
+        addSupportedDecision(UMLDecision.NAMING);
+        setKnowledgeTypes(Critic.KT_COMPLETENESS, Critic.KT_SYNTAX);
+        addTrigger("name");
     }
 
     /*
@@ -74,39 +71,19 @@ public class CrMissingStateName extends CrUML {
      */
     @Override
     public boolean predicate2(Object dm, Designer dsgr) {
-	if (!Model.getFacade().isAStateVertex(dm)) {
+        if (!(Model.getFacade().isAModelElement(dm))) {
             return NO_PROBLEM;
         }
-        if (Model.getFacade().isACompositeState(dm)
-                && Model.getFacade().isTop(dm)) {
-            return NO_PROBLEM;
-        }
-        if (Model.getFacade().isAFinalState(dm)) {
-            return NO_PROBLEM;
-        }
-        if (Model.getFacade().isAPseudostate(dm)) {
-            return NO_PROBLEM;
-        }
-        if (Model.getFacade().isAActionState(dm)) {
-            return NO_PROBLEM;
-        }
-        if (Model.getFacade().isAObjectFlowState(dm)) {
-            return NO_PROBLEM;
-        }
-
-	String myName = Model.getFacade().getName(dm);
-	if (myName == null || myName.equals("") || myName.length() == 0) {
-            return PROBLEM_FOUND;
-        }
-	return NO_PROBLEM;
+        return isNameMissing(dm) ? PROBLEM_FOUND : NO_PROBLEM;
     }
+
 
     /*
      * @see org.argouml.cognitive.Poster#getClarifier()
      */
     @Override
     public Icon getClarifier() {
-	return ClClassName.getTheInstance();
+        return ClClassName.getTheInstance();
     }
 
     /*
@@ -115,33 +92,28 @@ public class CrMissingStateName extends CrUML {
      */
     @Override
     public void initWizard(Wizard w) {
-	if (w instanceof WizMEName) {
-	    ToDoItem item = (ToDoItem) w.getToDoItem();
-	    Object me = item.getOffenders().get(0);
-	    String ins = super.getInstructions();
-	    String sug = super.getDefaultSuggestion();
-	    if (Model.getFacade().isAStateVertex(me)) {
-		Object sv = me;
-		int count = 1;
-		if (Model.getFacade().getContainer(sv) != null) {
-		    count =
-		        Model.getFacade().getSubvertices(
-		                Model.getFacade().getContainer(sv)).size();
-                }
-		sug = "S" + (count + 1);
-	    }
-	    ((WizMEName) w).setInstructions(ins);
-	    ((WizMEName) w).setSuggestion(sug);
-	}
+        if (w instanceof WizMEName) {
+            ToDoItem item = (ToDoItem) w.getToDoItem();
+            Object me = item.getOffenders().get(0);
+            String ins = super.getInstructions();
+            String sug = super.getDefaultSuggestion();
+            int count = 1;
+            if (Model.getFacade().getNamespace(me) != null) {
+                count =
+                        Model.getFacade().getOwnedElements(
+                                Model.getFacade().getNamespace(me)).size();
+            }
+            sug = Model.getFacade().getUMLClassName(me) + (count + 1);
+            ((WizMEName) w).setInstructions(ins);
+            ((WizMEName) w).setSuggestion(sug);
+        }
     }
 
     /*
      * @see org.argouml.cognitive.critics.Critic#getWizardClass(org.argouml.cognitive.ToDoItem)
      */
     @Override
-    public Class getWizardClass(ToDoItem item) {
-        return WizMEName.class;
-    }
+    public Class getWizardClass(ToDoItem item) { return WizMEName.class; }
 
     /*
      * @see org.argouml.uml.cognitive.critics.CrUML#getCriticizedDesignMaterials()
@@ -149,12 +121,8 @@ public class CrMissingStateName extends CrUML {
     @Override
     public Set<Object> getCriticizedDesignMaterials() {
         Set<Object> ret = new HashSet<Object>();
-        ret.add(Model.getMetaTypes().getStateVertex());
+        ret.add(Model.getMetaTypes().getUMLClass());
         return ret;
     }
-    
-    /**
-     * The UID.
-     */
-    private static final long serialVersionUID = 1181623952639408440L;
+
 }

--- a/src/argouml-app/src/org/argouml/uml/cognitive/critics/CrUML.java
+++ b/src/argouml-app/src/org/argouml/uml/cognitive/critics/CrUML.java
@@ -67,13 +67,13 @@ public class CrUML extends Critic {
      * Logger.
      */
     private static final Logger LOG =
-        Logger.getLogger(CrUML.class.getName());
+            Logger.getLogger(CrUML.class.getName());
 
-   /**
-    * By default looks for the localized strings at the <code>critics</code>
-    * Resource, but critics defined elsewhere (out of ArgoUML main tree)
-    * may override this parameter
-    */
+    /**
+     * By default looks for the localized strings at the <code>critics</code>
+     * Resource, but critics defined elsewhere (out of ArgoUML main tree)
+     * may override this parameter
+     */
     private String localizationPrefix = "critics";
 
     /**
@@ -158,7 +158,7 @@ public class CrUML extends Critic {
      */
     //@Override
     //public final void setHeadline(String s) {
-        //setupHeadAndDesc();
+    //setupHeadAndDesc();
     //}
 
     /**
@@ -194,7 +194,7 @@ public class CrUML extends Critic {
      * @return boolean problem found
      */
     public boolean predicate2(Object dm, Designer dsgr) {
-	return super.predicate(dm, dsgr);
+        return super.predicate(dm, dsgr);
     }
 
     ////////////////////////////////////////////////////////////////
@@ -214,8 +214,8 @@ public class CrUML extends Critic {
     public String expand(String res, ListSet offs) {
 
         if (offs.size() == 0) {
-	    return res;
-	}
+            return res;
+        }
 
         Object off1 = offs.get(0);
 
@@ -238,7 +238,7 @@ public class CrUML extends Critic {
             String evalStr = null;
             try {
                 evalStr =
-		    CriticOclEvaluator.getInstance().evalToString(off1, expr);
+                        CriticOclEvaluator.getInstance().evalToString(off1, expr);
             } catch (ExpansionException e) {
                 // Really ought to have a CriticException to throw here.
                 LOG.log(Level.SEVERE, "Failed to evaluate critic expression", e);
@@ -263,7 +263,7 @@ public class CrUML extends Critic {
      */
     @Override
     public ToDoItem toDoItem(Object dm, Designer dsgr) {
-	return new UMLToDoItem(this, dm, dsgr);
+        return new UMLToDoItem(this, dm, dsgr);
     }
 
     /**
@@ -282,4 +282,10 @@ public class CrUML extends Critic {
      * The UID.
      */
     private static final long serialVersionUID = 1785043010468681602L;
+    // Utility method for checking if a name is missing
+    boolean isNameMissing(Object element) {
+        String myName = Model.getFacade().getName(element);
+        return (myName == null || myName.equals("") || myName.length() == 0);
+    }
+
 }


### PR DESCRIPTION
fixes: https://github.com/rilling/argoumlFall2024/issues/23

The pull request conforms updated isNameMissing, in the CrUML file to handle the common logic for both classes (CrMissingStateName and CrMissingClassName) will then call this utility method, streamlining the code and eliminating duplication. 